### PR TITLE
Add support for symbols

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.cgrand/seqexp "0.6.2"
+(defproject net.cgrand/seqexp "0.6.3-SNAPSHOT"
   :description "Regular expressions for sequences."
   :url "http://github.com/cgrand/seqexp"
   :license {:name "Eclipse Public License"

--- a/src/net/cgrand/seqexp.clj
+++ b/src/net/cgrand/seqexp.clj
@@ -41,6 +41,9 @@
   Object
   (instructions [x]
     (instructions #(= x %)))
+  clojure.lang.Symbol
+  (instructions [x]
+    (instructions #(= x %)))
   clojure.lang.AFn
   (instructions [f]
     (asm
@@ -254,7 +257,7 @@
       (fetch [bank] init))))
 
 (defn comp-bank [banks]
-  (reify RegisterBank 
+  (reify RegisterBank
     (save0 [bank [k & ks] v]
       (comp-bank (update banks k save0 ks v)))
     (save1 [bank [k & ks] v]
@@ -393,7 +396,7 @@
 
 (defn- map-registers [re f]
   (->Pattern
-    (into [] 
+    (into []
       (map (fn [[op arg :as inst]]
              (case op
                (:save0 :save1) [op (f arg)]
@@ -416,5 +419,3 @@
        coll (comp-bank
               {:rest unmatched-rest
                :match (tree-bank mk-node)})))))
-
-

--- a/test/net/cgrand/seqexp_test.clj
+++ b/test/net/cgrand/seqexp_test.clj
@@ -8,7 +8,9 @@
     3 [3] [3]
     3 [3 3] [3]
     3 [3 4] [3]
-    3 [4 3] nil))
+    3 [4 3] nil
+    'a '(a b) '(a)
+    'a '(b a) nil))
 
 (deftest predicates
   (are [se s m]
@@ -86,4 +88,3 @@
     (se/cat (se/*? se/_) (se/?= odd?) (se/as :a (se/* se/_))) [2 4 5 6 8] [5 6 8]
     (se/cat (se/*? se/_) (se/?= odd? odd?) (se/as :a (se/* se/_))) [2 4 5 6 7 9 8 11] [7 9 8 11]
     (se/cat (se/as :a (se/*? se/_)) (se/?= odd?)) [2 4 5 6 8] [2 4]))
-


### PR DESCRIPTION
```
net.cgrand.seqexp> (cat 'a)
#net.cgrand.seqexp.Pattern{:ops ([:pred a])}
```

Because symbols are instances of `AFn`, they're passed through as preds rather than given an equality pred like most literals.